### PR TITLE
Fixed syntax error in migration

### DIFF
--- a/pkg/common/db/migration/migrations/011_slot_resources_FK_fix.sql
+++ b/pkg/common/db/migration/migrations/011_slot_resources_FK_fix.sql
@@ -5,7 +5,7 @@ BEGIN TRANSACTION;
 -- Makes it easier to delete slots
 ALTER TABLE slot_resources DROP CONSTRAINT slot_resources_slot_id_fkey;
 
-ALTER TABLE slot_resources ALTER CONSTRAINT slot_resources_slot_id_fkey FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE;
+ALTER TABLE slot_resources ADD CONSTRAINT slot_resources_slot_id_fkey  FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE;
 
 UPDATE migrations
 SET succeeded = true


### PR DESCRIPTION
This fixes a small syntax error in the latest migration